### PR TITLE
Fix script not actually checking for ./.running

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -97,8 +97,21 @@ server_start () {
 		echo "Downloading latest Paper server JAR file for version ${mcver}..."
 		wget $dlbuild -O $jarname >/dev/null 2>&1
 	fi
-	touch ./.running
+	test -f ./.running
 	lastexit=$?
+	catch_error
+	case $error in
+		0)
+			running=1
+		;;
+		1)
+			running=0
+		;;
+		*)
+			critical_stop
+		;;
+	esac
+	touch ./.running
 	if [ $lastexit -gt 1 ]; then
 		critical_stop
 	elif [ $lastexit = 1 ]; then


### PR DESCRIPTION
The script had a bug where it would not check for ./.running during the server start function; instead it would just touch the file without doing anything else. This was not intended behavior; I had intended for it to actually be a way to detect if the server is running. I had forgotten that touch doesn't care if the file already exists or not, so long as the directory to contain the file is writable by the user and already exists. I implemented one final case/esac and test -f to the start function, just before it touches the file, in POSIX-compliant fashion.

The script may produce warnings or tips when ran through ShellCheck, however please note that the warnings and tips may actually break this script if the fixes get implemented. What I'm saying is this: don't just fork this JUST to make it produce no output from a ShellCheck pass, because some programs RELY on the globbing nature of some of the variables, and it doesn't break the script to keep all the variables intentionally unquoted.

The other warning comes from how `read -r` functions in DASH/SH, as you always have to specify a variable for read to pipe to. For the cases where it doesn't need to use the input in any way beyond just having a pause function, I have it set up with an otherwise completely unused variable that means nothing (hence its name, nil). Ignore the warning about it not being used if you run it through ShellCheck; again, NOT specifying a variable with `read` is a BASHISM, not something all shells can handle.